### PR TITLE
Fixing Dockerfile to start from the earthlab image

### DIFF
--- a/r-spatial/Dockerfile
+++ b/r-spatial/Dockerfile
@@ -1,73 +1,16 @@
-FROM rocker/rstudio:latest
+FROM earthlab/r-spatial-aws
 
-# much below is from the rocker/geospatial and earthlab/r-spatial-aws Dockerfile
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
-    gdal-bin \
-    lbzip2 \
-    libfftw3-dev \
-    libgdal-dev \
-    libgeos-dev \
-    libgsl0-dev \
-    libgl1-mesa-dev \
-    libglu1-mesa-dev \
-    libhdf4-alt-dev \
-    libhdf5-dev \
-    liblwgeom-dev \
-    libproj-dev \
-    libnetcdf-dev \
-    libsqlite3-dev \
-    libssh2-1-dev \
-    libssl-dev \
-    libudunits2-dev \
-    python-pip \
-    tk-dev \
-    unixodbc-dev
+    libcairo2-dev \
+    libjq-dev \ 
+    libprotobuf-dev \
+    libv8-3.14-dev \
+    protobuf-compiler
 
 RUN install2.r --error \
-    assertthat \
-    RColorBrewer \
-    RandomFields \
-    classInt \
-    deldir \
-    doParallel \
-    gdalUtils \
-    ggmap \
-    ggthemes \
-    gstat \
-    httr \
-    lidR \
-    mapdata \
-    maptools \
-    mapview \
-    MODIS \
-    ncdf4 \
-    parallel \
-    proj4 \
-    raster \
-    rasterVis \
-    RCurl \
-    rgdal \
-    rgeos \
-    rlas \
-    sf \
-    sp \
-    spacetime \
-    spatstat \
-    spdep \
-    snowfall \
-    tidyverse \
-    tmap \
-    viridis \
-    geoR \
-    geosphere \
-    ## from bioconductor
-  && R -e "source('https://bioconductor.org/biocLite.R'); biocLite('BiocInstaller')" \
-  && R -e "BiocInstaller::biocLite('rhdf5')"
-
-RUN pip install wheel \ 
-  && pip install awscli
+    tmap 
 
 EXPOSE 8787
 


### PR DESCRIPTION
Heya @NateMietk - there were some system libraries missing for the `tmap` package to work. This PR includes those and also uses the `FROM` argument in the Dockerfile to start from the earthlab image. 